### PR TITLE
Update to 1.20.1 and build with OpenSSL 3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,8 @@ channels:
   staging_openssl3: openssl3
 
 aggregate_branch: openssl3_builds
+
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  staging_openssl3: openssl3
+
+aggregate_branch: openssl3_builds

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,12 +33,12 @@ requirements:
     - pkg-config  # [unix]
     - make        # [unix]
   host:
-    - libedit     # [unix]
-    - openssl 3.0.8    # [unix]
-    - tk
+    - libedit 3.1.20221030  # [unix]
+    - openssl 3.0.8  # [unix]
+    - tk 8.6.12
   run:
     - {{ pin_compatible('libedit') }}  # [unix]
-    - openssl >=3.0.8,<4.0a0
+    - openssl 3.*
 test:
   requires:
     - python 3.11

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.19.4" %}
+{% set version = "1.20.1" %}
 
 package:
   name: krb5
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/krb5/krb5/archive/krb5-{{ version }}-final.tar.gz
-  sha256: bb44dfd7ab4fd80c5ba4c7a751ad4669f6e0bd2d418fe6bf94fbc0d0af278a02
+  sha256: ec3861c3bec29aa8da9281953c680edfdab1754d1b1db8761c1d824e4b25496a
 
 build:
   number: 0
@@ -32,24 +32,16 @@ requirements:
     - perl        # [win]
     - pkg-config  # [unix]
     - make        # [unix]
-    - python 3.7  # [not (win or arm64)]
-    - python 3.8  # [arm64]
-    - python      # [win]
   host:
     - libedit     # [unix]
-    - openssl     # [unix]
+    - openssl 3.0.8    # [unix]
     - tk
   run:
     - {{ pin_compatible('libedit') }}  # [unix]
-
+    - openssl >=3.0.8,<4.0a0
 test:
   requires:
-    # without this the solver goes into a strange corner and returns python 2.0
-    - python 3.7.*  # [not (win or arm64)]
-    - python 3.8.*  # [arm64]
-    # Python 3.8 changed the default behavior of `ctypes.CDLL`, and it's more
-    # expedient to add this constraint rather than rewrite the test script.
-    - python <3.8   # [win]
+    - python 3.11
 
 about:
   home: https://web.mit.edu/kerberos/
@@ -59,7 +51,7 @@ about:
   summary: 'A network authentication protocol.'
   description: |
     Kerberos is a network authentication protocol. It is designed to provide strong authentication for client/server applications by using secret-key cryptography. 
-  doc_url: https://web.mit.edu/kerberos/krb5-1.19/doc/index.html
+  doc_url: https://web.mit.edu/kerberos/krb5-1.20/doc/index.html
   dev_url: https://kerberos.org/dist/index.html
 
 extra:


### PR DESCRIPTION
Update to 1.20.1 and build with OpenSSL 3.

Notes:
* Removed python from the build dependencies since I can't find where it's used. And searching the krb5 code base, it doesn't seems to be used at all in the builds.
