### PR TITLE
Rebuild on Windows with openssl 3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2157d92020d408ed63ebcd886a92d1346a1383b0f91123a0473b4f69b4a24861
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and vc<14]
   run_exports:
     # stable within minor revisions: https://abi-laboratory.pro/tracker/timeline/krb5/
@@ -25,6 +25,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - bison       # [not win]
@@ -35,11 +36,11 @@ requirements:
     - make        # [unix]
   host:
     - libedit 3.1.20221030  # [unix]
-    - openssl {{ openssl }} # [unix]
+    - openssl {{ openssl }}
     - tk 8.6.12
   run:
     - {{ pin_compatible('libedit') }}  # [unix]
-    - openssl  # exact pin handled through openssl run_exports
+
 test:
   requires:
     - python 3.11


### PR DESCRIPTION
krb5 1.21.3 b1

**Destination channel:** defaults

### Links

- [PKG-8886](https://anaconda.atlassian.net/browse/PKG-8886)
- [Upstream repository](https://github.com/krb5/krb5/tree/krb5-1.21.3-final)
### Explanation of changes:

- Let Windows build find openssl in conda env instead of on host system


[PKG-8886]: https://anaconda.atlassian.net/browse/PKG-8886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ