### PR TITLE
PKG-13345: add constrains between krb5 and libkrb5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: 2157d92020d408ed63ebcd886a92d1346a1383b0f91123a0473b4f69b4a24861
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and vc<14]
   missing_dso_whitelist:
     - api-ms-win-core-winrt-error-l1-1-0.dll   # [win]
@@ -132,6 +132,8 @@ outputs:
       run:
         - lmdb         # [unix]
         - openssl
+      run_constrained:
+        - krb5 {{ version }}
     test:
       commands:
         - set -x                                  # [unix]


### PR DESCRIPTION
krb5 1.21.3 (rebuild with constrained libkrb5)

**Destination channel:** defaults

### Links

- [PKG-13345](https://anaconda.atlassian.net/browse/PKG-13345) 

### Explanation of changes:

- Fix to avoid using incompatible krb5 versions


[PKG-13345]: https://anaconda.atlassian.net/browse/PKG-13345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ