### PR TITLE
Normalize krb5 upstream tag parsing (prefix + bounded suffix)

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -3,9 +3,9 @@ upstream_sources:
   - github:
       identifier: krb5/krb5
       use_max_tag: true
-      include_regex: ^krb5-\d+\.\d+\.\d+(?:-.+)?$
-      strip_prefix: krb5-
-      from_pattern: ^(\d+\.\d+\.\d+)(?:-.+)?$
+      include_regex: ^krb5-\d+\.\d+\.\d+(?:-(?:final|release|ga))?$
+      prefix: krb5-
+      from_pattern: ^(\d+\.\d+\.\d+)(?:-(?:final|release|ga))?$
       to_pattern: \1
     packages:
       - krb5


### PR DESCRIPTION
## Summary
- replace legacy strip_prefix with prefix: krb5-
- tighten regex/from_pattern to strip only known suffixes (final|release|ga)
- keep package list unchanged (krb5, libkrb5)

## Context
Distro-db still reported upstream values like krb5-1.22.2-final; normalize to plain semver for tracking parity.

## Validation
- checked existing anaconda.yaml in repo
- verified normalized pattern path used by current nvchecker flow