### PR TITLE
v1.22.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "krb5" %}
-{% set version = "1.22.1" %}
+{% set version = "1.22.2" %}
 
 # Platform-specific prefixes and suffixes
 {% set win_prefix = "Library/" %}
@@ -11,10 +11,10 @@ package:
 
 source:
   url: https://github.com/krb5/{{ name }}/archive/{{ name }}-{{ version }}-final.tar.gz
-  sha256: d7dd1ded54c1c2d3381da4a266935feda6ba6398155720df27e2975bd5a39239
+  sha256: 289f5bb81d1f2f8d5eecebe56a056aeed95d35fd9bb4a7071c5dd7ad4b3fe888
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win and vc<14]
   missing_dso_whitelist:
     - api-ms-win-core-winrt-error-l1-1-0.dll   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [win and vc<14]
   missing_dso_whitelist:
     - api-ms-win-core-winrt-error-l1-1-0.dll   # [win]
     - api-ms-win-core-winrt-l1-1-0.dll         # [win]
@@ -155,8 +154,8 @@ outputs:
         - test -f $PREFIX/include/krb5/krb5.h     # [unix]
         - test -f $PREFIX/bin/krb5-config         # [unix]
         - echo on                                 # [win]
-        - if exist "%PREFIX%\\Library\\bin\\krb5_64.dll" (exit 0) else (exit 1) # [win]
-        - if exist "%PREFIX%\\Library\\include\\krb5.h" (exit 0) else (exit 1)  # [win]
+        - if not exist "%PREFIX%\\Library\\bin\\krb5_64.dll" exit 1  # [win]
+        - if not exist "%PREFIX%\\Library\\include\\krb5.h" exit 1   # [win]
 
   - name: {{ name }}
     script: build-krb5-split.sh   # [unix]
@@ -260,8 +259,8 @@ outputs:
         - test -f $PREFIX/sbin/krb5kdc     # [unix]
         - echo on                          # [win]
         # Test for Windows executables
-        - if exist "%PREFIX%\\Library\\bin\\kinit.exe" (exit 0) else (exit 1)  # [win]
-        - if exist "%PREFIX%\\Library\\bin\\klist.exe" (exit 0) else (exit 1)  # [win]
+        - if not exist "%PREFIX%\\Library\\bin\\kinit.exe" exit 1  # [win]
+        - if not exist "%PREFIX%\\Library\\bin\\klist.exe" exit 1  # [win]
 
 about:
   home: https://web.mit.edu/kerberos


### PR DESCRIPTION
krb5 1.22.2

**Destination channel:**  defaults

### Links

- [PKG-15349](https://anaconda.atlassian.net/browse/PKG-15349) 
- [Upstream repository](https://github.com/krb5/krb5/tree/krb5-1.22.2-final)
- [Upstream changelog/diff](https://github.com/krb5/krb5/compare/krb5-1.22.1-final...krb5-1.22.2-final)


### Explanation of changes:

- Bump version and SHA
- This version builds cleanly on win-arm64 replacing the hacks in #27 
- Fix windows tests: Previously the second test wasn't running because of the `exit 0`


[PKG-15349]: https://anaconda.atlassian.net/browse/PKG-15349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ